### PR TITLE
Fix binding conversion failure

### DIFF
--- a/Jurassic/Compiler/Binders/JSBinder.cs
+++ b/Jurassic/Compiler/Binders/JSBinder.cs
@@ -279,11 +279,27 @@ namespace Jurassic.Compiler
                 EmitConversion.ToInteger(il, PrimitiveTypeUtilities.ToPrimitiveType(fromType));
             else if (typeof(ObjectInstance).IsAssignableFrom(toType))
             {
-                EmitConversion.Convert(il, PrimitiveTypeUtilities.ToPrimitiveType(fromType), PrimitiveType.Object);
-                if (toType != typeof(ObjectInstance))
+                if (toType == typeof(ObjectInstance))
                 {
-                    // Convert to null if the from type isn't compatible with the to type.
-                    // For example, if the target type is FunctionInstance and the from type is ArrayInstance, then pass null.
+                    // Generic ObjectInstance: wrapping primitives in their JS equivalents is correct.
+                    EmitConversion.Convert(il, PrimitiveTypeUtilities.ToPrimitiveType(fromType), PrimitiveType.Object);
+                }
+                else
+                {
+                    // Specific ObjectInstance subtype (e.g. FunctionInstance, a CLR-bound class).
+                    // Do NOT wrap the primitive first — for a string argument, that calls
+                    // engine.String.Construct() which accesses InstancePrototype and can crash
+                    // with AccessViolationException. The wrap is also pointless: isinst would
+                    // return null anyway since e.g. StringObject is not FunctionInstance.
+                    // Instead, check the type directly and throw a TypeError if wrong.
+                    var typeCheckPassed = il.CreateLabel();
+                    il.Duplicate();
+                    il.IsInstance(toType);
+                    il.BranchIfNotNull(typeCheckPassed);
+                    il.Pop();
+                    EmitHelpers.EmitThrow(il, ErrorType.TypeError,
+                        string.Format("Expected argument of type {0}.", toType.Name));
+                    il.DefineLabelPosition(typeCheckPassed);
                     il.IsInstance(toType);
                 }
             }

--- a/Jurassic/Compiler/Binders/JSBinder.cs
+++ b/Jurassic/Compiler/Binders/JSBinder.cs
@@ -286,20 +286,22 @@ namespace Jurassic.Compiler
                 }
                 else
                 {
-                    // Specific ObjectInstance subtype (e.g. FunctionInstance, a CLR-bound class).
-                    // Do NOT wrap the primitive first — for a string argument, that calls
-                    // engine.String.Construct() which accesses InstancePrototype and can crash
-                    // with AccessViolationException. The wrap is also pointless: isinst would
-                    // return null anyway since e.g. StringObject is not FunctionInstance.
-                    // Instead, check the type directly and throw a TypeError if wrong.
+                    // Peter 2026-04-29
+                    // Specific ObjectInstance subtype:
+                    // Don't call EmitConversion.Convert(il... Causes ProcessCorruptedStateExceptions
+                    // Instead, check the type with this code:
                     var typeCheckPassed = il.CreateLabel();
                     il.Duplicate();
                     il.IsInstance(toType);
                     il.BranchIfNotNull(typeCheckPassed);
+                    // If we didn'r branch to typeCheckPassed - throw exception
                     il.Pop();
                     EmitHelpers.EmitThrow(il, ErrorType.TypeError,
                         string.Format("Expected argument of type {0}.", toType.Name));
+
+                    // If branch here - the type checked out OK
                     il.DefineLabelPosition(typeCheckPassed);
+                    // Still need to convert it because the last converted was consumed by BranchIfNotNull
                     il.IsInstance(toType);
                 }
             }

--- a/Jurassic/Compiler/Binders/JSBinder.cs
+++ b/Jurassic/Compiler/Binders/JSBinder.cs
@@ -294,7 +294,7 @@ namespace Jurassic.Compiler
                     il.Duplicate();
                     il.IsInstance(toType);
                     il.BranchIfNotNull(typeCheckPassed);
-                    // If we didn'r branch to typeCheckPassed - throw exception
+                    // If we didn't branch to typeCheckPassed - throw exception
                     il.Pop();
                     EmitHelpers.EmitThrow(il, ErrorType.TypeError,
                         string.Format("Expected argument of type {0}.", toType.Name));

--- a/Jurassic/Jurassic.csproj
+++ b/Jurassic/Jurassic.csproj
@@ -6,7 +6,7 @@
     <Authors>Paul Bartrum</Authors>
     <Company />
     <Description>A .NET library to parse and execute JavaScript code.</Description>
-    <Version>3.3.1</Version>
+    <Version>3.3.2</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GeneratePackageOnBuild Condition="'$(Configuration)' == 'Release'">true</GeneratePackageOnBuild>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
A JS statement like Wait.forField( Field f, time ms ) will cause an AccessViolationException if called with a primitive parameter instead of  the Fielfd parameter. (For instance Wait.forField( "", 10 ) )

The error occurs before calling the native method, in the Jurrasic code that sets up the call. It only happens when using a SubClass of ObjectInstance as parameter and calling it with a primitive argument

I can't find of a way to fix it in our code so the fix is here in Jurrasic

An AccessViolationException is a ProcessCorruptedStateException, and can not bu handled by ordinary try catch. (It can be forced to work but it leaves the memory in a corrupt state so better to exit in this case.

